### PR TITLE
Fix ambiguous reference for Term

### DIFF
--- a/src/LojysambanLib.hs
+++ b/src/LojysambanLib.hs
@@ -8,7 +8,7 @@ module LojysambanLib (ask, readRules, end) where
 import LojbanTools
 import Prolog2 hiding (ask)
 import qualified Prolog2 as P
-import Language.Lojban.Parser hiding (LA, Brivla, KOhA, GOhA, NA, LerfuString, LI)
+import Language.Lojban.Parser hiding (LA, Brivla, KOhA, GOhA, NA, LerfuString, LI, Term)
 import qualified Language.Lojban.Parser as P
 import Data.Maybe
 import Data.Either


### PR DESCRIPTION
Because both Prolog2 and Language.Lojban.Parser got a Term reference, we may need to hide one of them to make the program work.
